### PR TITLE
feat: Github Checks and Release Drafter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,22 @@
 # Order is important: the last matching pattern has the highest precedence
 
 # These owners will be the default owners for everything
-*  @NewClassrooms/cloud-posse
+*             @cloudposse/engineering
 
-# New Classrooms should add their own teams here as well. As of Feb 14, 2024, no other teams have access to this repo, and therefore CODEOWNERS validation will fail. For example, uncomment the following and delete the line above
-# *  @NewClassrooms/cloud-posse @NewClassrooms/engineering
+# Cloud Posse must review any changes to Makefiles
+**/Makefile   @cloudposse/engineering
+**/Makefile.* @cloudposse/engineering
+
+# Cloud Posse must review any changes to GitHub actions
+.github/*     @cloudposse/engineering
+
+# Cloud Posse must review any changes to standard context definition,
+# but some changes can be rubber-stamped.
+**/*.tf       @cloudposse/engineering @cloudposse/approvers
+README.yaml   @cloudposse/engineering @cloudposse/approvers
+README.md     @cloudposse/engineering @cloudposse/approvers
+docs/*.md     @cloudposse/engineering @cloudposse/approvers
+
+# Cloud Posse Admins must review all changes to CODEOWNERS or the mergify configuration
+.github/mergify.yml @cloudposse/admins
+.github/CODEOWNERS  @cloudposse/admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Use this file to define individuals or teams that are responsible for code in a repository.
+# Read more: <https://help.github.com/articles/about-codeowners/>
+#
+# Order is important: the last matching pattern has the highest precedence
+
+# These owners will be the default owners for everything
+*  @NewClassrooms/cloud-posse
+
+# New Classrooms should add their own teams here as well. As of Feb 14, 2024, no other teams have access to this repo, and therefore CODEOWNERS validation will fail. For example, uncomment the following and delete the line above
+# *  @NewClassrooms/cloud-posse @NewClassrooms/engineering

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,10 +15,10 @@
 
 # Cloud Posse must review any changes to standard context definition,
 # but some changes can be rubber-stamped.
-**/*.tf       @cloudposse/engineering @cloudposse/approvers
-README.yaml   @cloudposse/engineering @cloudposse/approvers
-README.md     @cloudposse/engineering @cloudposse/approvers
-docs/*.md     @cloudposse/engineering @cloudposse/approvers
+**/*.tf       @cloudposse/engineering
+README.yaml   @cloudposse/engineering
+README.md     @cloudposse/engineering
+docs/*.md     @cloudposse/engineering
 
 # Cloud Posse Admins must review all changes to CODEOWNERS or the mergify configuration
 .github/mergify.yml @cloudposse/admins

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## what
+
+- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
+- Use bullet points to be concise and to the point.
+
+## why
+
+- Provide the justifications for the changes (e.g. business case).
+- Describe why these changes were made (e.g. why do these commits fix the problem?)
+- Use bullet points to be concise and to the point.
+
+## references
+
+- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
+- Use `closes #123`, if this PR closes a GitHub issue `#123`
+- Use `closes JIRA-123`, if this PR closes a Jira Issue `JIRA-123` where `JIRA` is the project abbreviation. 

--- a/.github/REINTEGRATE_PULL_REQUEST_TEMPLATE.md
+++ b/.github/REINTEGRATE_PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,13 @@
 ## Hotfix Changes:
+
+### Summary:
+<!-- Diff summary - START -->
+<!-- Diff summary - END -->
+
+### Commits:
+<!-- Diff commits - START -->
+<!-- Diff commits - END -->
+
+### Files:
+<!-- Diff files - START -->
+<!-- Diff files - END -->

--- a/.github/REINTEGRATE_PULL_REQUEST_TEMPLATE.md
+++ b/.github/REINTEGRATE_PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,1 @@
 ## Hotfix Changes:
-
-### Summary:
-<!-- Diff summary - START -->
-<!-- Diff summary - END -->
-
-### Commits:
-<!-- Diff commits - START -->
-<!-- Diff commits - END -->
-
-### Files:
-<!-- Diff files - START -->
-<!-- Diff files - END -->

--- a/.github/configs/environment.yaml
+++ b/.github/configs/environment.yaml
@@ -2,4 +2,5 @@
 environment-info-repo: infra-live
 implementation_path: .github/environments
 implementation_file: ecspresso.yaml
-implementation_ref: main
+  #implementation_ref: main
+implementation_ref: fix/ecs-example

--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,0 +1,18 @@
+container:
+  - components/docker/**/Dockerfile
+  - rootfs/**
+
+docs:
+  - docs/**
+  - README.md
+
+automation:
+  - .github/**
+  - .spacelift/**
+  - Makefile
+  - .pre-commit-config.yaml
+
+configuration:
+  - stacks/**
+
+

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,6 @@
+{
+  "prConcurrentLimit": 5,
+  "extends": [
+    "config:base"
+  ]
+}

--- a/.github/workflows/ecspresso-feature-branch.yml
+++ b/.github/workflows/ecspresso-feature-branch.yml
@@ -14,12 +14,6 @@ name: |-
         branches: [ 'master' ]
         types: [opened, synchronize, reopened, closed, labeled, unlabeled]
     
-    permissions:
-      pull-requests: write
-      deployments: write
-      id-token: write
-      contents: read
-    
     jobs:
       do:
         uses: ./.github/workflows/ecspresso-feature-branch.yml
@@ -91,16 +85,6 @@ on:
       ecr-iam-role:
         description: "IAM Role ARN provide ECR write/read access"
         required: true
-
-permissions:
-  pull-requests: write
-  deployments: write
-  id-token: write
-  contents: read
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
 
 jobs:
   ci:

--- a/.github/workflows/ecspresso-hotfix-branch.yml
+++ b/.github/workflows/ecspresso-hotfix-branch.yml
@@ -14,12 +14,6 @@ name: |-
         branches: [ 'release/**' ]
         types: [opened, synchronize, reopened, closed, labeled, unlabeled]
     
-    permissions:
-      pull-requests: write
-      deployments: write
-      id-token: write
-      contents: read
-    
     jobs:
       do:
         uses: ./.github/workflows/ecspresso-hotfix-branch.yml
@@ -91,16 +85,6 @@ on:
       ecr-iam-role:
         description: "IAM Role ARN provide ECR write/read access"
         required: true
-
-permissions:
-  pull-requests: write
-  deployments: write
-  id-token: write
-  contents: read
-
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
 
 jobs:
   ci:

--- a/.github/workflows/ecspresso-hotfix-mixin.yml
+++ b/.github/workflows/ecspresso-hotfix-mixin.yml
@@ -13,10 +13,6 @@ name: |-
       release:
         types: [published]
   
-    permissions:
-      id-token: write
-      contents: write
-  
     jobs:
       hotfix:
         name: release / branch
@@ -43,14 +39,6 @@ on:
         description: "Release version tag"
         required: true
         type: string
-
-permissions:
-  id-token: write
-  contents: write
-
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
 
 jobs:
   create:

--- a/.github/workflows/ecspresso-hotfix-release.yml
+++ b/.github/workflows/ecspresso-hotfix-release.yml
@@ -13,10 +13,6 @@ name: |-
       push:
         branches: [ 'release/**' ]
     
-    permissions:
-      contents: write
-      id-token: write
-    
     jobs:
       do:
         uses: ./.github/workflows/ecspresso-hotfix-release.yml
@@ -75,14 +71,6 @@ on:
       ecr-iam-role:
         description: "IAM Role ARN provide ECR write/read access"
         required: true
-
-permissions:
-  contents: write
-  id-token: write
-
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
 
 jobs:
   ci:

--- a/.github/workflows/ecspresso-main-branch.yml
+++ b/.github/workflows/ecspresso-main-branch.yml
@@ -109,5 +109,3 @@ jobs:
   release:
     uses:  ./.github/workflows/workflow-controller-draft-release.yml
     needs: [ cd ]
-    secrets:
-      github-private-actions-pat: ${{ secrets.github-private-actions-pat }}

--- a/.github/workflows/ecspresso-main-branch.yml
+++ b/.github/workflows/ecspresso-main-branch.yml
@@ -1,7 +1,7 @@
 name: |-
   Main branch workflow
   
-  Build, test Docker image, deploy it with Spacelift on `dev` environment and draft new release  
+  Build, test Docker image, and deploy it with ecspresso into the `dev` environment and draft new release  
   
   ### Usage 
   
@@ -12,10 +12,6 @@ name: |-
     on:
       push:
         branches: [ master ]
-    
-    permissions:
-      contents: write
-      id-token: write
     
     jobs:
       do:
@@ -29,7 +25,6 @@ name: |-
           secret-outputs-passphrase: "$\{\{ secrets.GHA_SECRET_OUTPUT_PASSPHRASE }}"
           ecr-region: "$\{\{ secrets.ECR_REGION }}"
           ecr-iam-role: "$\{\{ secrets.ECR_IAM_ROLE }}"
-
   ```
 
 on:
@@ -71,14 +66,6 @@ on:
       ecr-iam-role:
         description: "IAM Role ARN provide ECR write/read access"
         required: true
-
-permissions:
-  contents: write
-  id-token: write
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
 
 jobs:
   ci:

--- a/.github/workflows/ecspresso-release.yml
+++ b/.github/workflows/ecspresso-release.yml
@@ -13,10 +13,6 @@ name: |-
       release:
         types: [published]
     
-    permissions:
-      id-token: write
-      contents: write
-    
     jobs:
       perform:
         uses: ./.github/workflows/ecspresso-release.yml
@@ -76,14 +72,6 @@ on:
       ecr-iam-role:
         description: "IAM Role ARN provide ECR write/read access"
         required: true
-
-permissions:
-  id-token: write
-  contents: write
-
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
 
 jobs:
   ci:

--- a/.github/workflows/ecspresso-rollback.yml
+++ b/.github/workflows/ecspresso-rollback.yml
@@ -53,16 +53,7 @@ on:
         description: "IAM Role ARN provide ECR write/read access"
         required: true
 
-permissions:
-  id-token: write
-  contents: write
-
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
-
 jobs:
-
   setup:
     runs-on: ["self-hosted"]
     steps:

--- a/.github/workflows/ecspresso-rollback.yml
+++ b/.github/workflows/ecspresso-rollback.yml
@@ -55,7 +55,7 @@ on:
 
 jobs:
   setup:
-    runs-on: ["self-hosted"]
+    runs-on: ["ubuntu-latest"]
     steps:
       - name: Sanitize Organization
         id: lowercase_org

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -4,11 +4,9 @@ on:
     branches: [ 'main' ]
     types: [opened, synchronize, reopened, closed, labeled, unlabeled]
 
-permissions:
-  pull-requests: write
-  deployments: write
-  id-token: write
-  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:          
   do:

--- a/.github/workflows/hotfix-branch.yaml
+++ b/.github/workflows/hotfix-branch.yaml
@@ -4,11 +4,9 @@ on:
     branches: [ 'release/**' ]
     types: [opened, synchronize, reopened, closed, labeled, unlabeled]
 
-permissions:
-  pull-requests: write
-  deployments: write
-  id-token: write
-  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   do:

--- a/.github/workflows/hotfix-enabled.yaml
+++ b/.github/workflows/hotfix-enabled.yaml
@@ -3,9 +3,9 @@ on:
   release:
     types: [published]
 
-permissions:
-  id-token: write
-  contents: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   hotfix:

--- a/.github/workflows/hotfix-release.yaml
+++ b/.github/workflows/hotfix-release.yaml
@@ -3,9 +3,9 @@ on:
   push:
     branches: [ 'release/**' ]
 
-permissions:
-  contents: write
-  id-token: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   do:

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -6,8 +6,7 @@ permissions:
   pull-requests: write
 jobs:
   label:
-    runs-on:
-      - self-hosted
+    runs-on: ["ubuntu-latest"]
 
     steps:
       - uses: actions/labeler@v4

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,17 @@
+name: Labeler
+on: [pull_request]
+
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  label:
+    runs-on:
+      - self-hosted
+
+    steps:
+      - uses: actions/labeler@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yaml
+

--- a/.github/workflows/main-branch.yaml
+++ b/.github/workflows/main-branch.yaml
@@ -3,9 +3,9 @@ on:
   push:
     branches: [ main ]
 
-permissions:
-  contents: write
-  id-token: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   do:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,9 +3,9 @@ on:
   release:
     types: [published]
 
-permissions:
-  id-token: write
-  contents: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   perform:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -43,8 +43,7 @@ jobs:
 
   docs:
     name: "docs"
-    runs-on:
-      - self-hosted
+    runs-on: ["ubuntu-latest"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,16 +40,3 @@ jobs:
       name: "Syntax check of CODEOWNERS"
       with:
         checks: "syntax,duppatterns"
-
-  docs:
-    name: "docs"
-    runs-on: ["ubuntu-latest"]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Check spelling
-        uses: crate-ci/typos@v1.16.25
-        with:
-          files: |
-            README.yaml
-            ./docs

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,8 +18,7 @@ concurrency:
 jobs:
   codeowners:
     name: "codeowners"
-    runs-on:
-      - self-hosted
+    runs-on: ["ubuntu-latest"]
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v4

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,57 @@
+name: 🐛 Validate
+on:
+  workflow_dispatch:
+
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches:
+      - main
+
+# Concurrency ensures only the latest push for this PR will run at a time
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  codeowners:
+    name: "codeowners"
+    runs-on:
+      - self-hosted
+    steps:
+    - name: "Checkout source code at current commit"
+      uses: actions/checkout@v4
+      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
+    - uses: mszostok/codeowners-validator@v0.7.1
+      if: github.event.pull_request.head.repo.full_name == github.repository
+      name: "Full check of CODEOWNERS"
+      with:
+        # For now, remove "files" check to allow CODEOWNERS to specify non-existent
+        # files so we can use the same CODEOWNERS file for Terraform and non-Terraform repos
+        #   checks: "files,syntax,owners,duppatterns"
+        #checks: "syntax,owners,duppatterns"
+        checks: "syntax,duppatterns"
+        # GitHub access token is required only if the `owners` check is enabled
+        github_access_token: "${{ secrets.GITHUB_TOKEN }}"
+      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
+    - uses: mszostok/codeowners-validator@v0.7.1
+      if: github.event.pull_request.head.repo.full_name != github.repository
+      name: "Syntax check of CODEOWNERS"
+      with:
+        checks: "syntax,duppatterns"
+
+  docs:
+    name: "docs"
+    runs-on:
+      - self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check spelling
+        uses: crate-ci/typos@v1.16.25
+        with:
+          files: |
+            README.yaml
+            ./docs

--- a/.github/workflows/workflow-cd-preview-ecspresso.yml
+++ b/.github/workflows/workflow-cd-preview-ecspresso.yml
@@ -298,11 +298,6 @@ jobs:
     strategy:
       matrix:
         env: ${{ fromJson(needs.preview.outputs.destroy_envs) }}
-    permissions:
-      pull-requests: write
-      deployments: write
-      id-token: write
-      contents: read
     needs: [ preview ]
     steps:
       - uses: cloudposse/github-action-secret-outputs@0.1.1

--- a/.github/workflows/workflow-controller-draft-release.yml
+++ b/.github/workflows/workflow-controller-draft-release.yml
@@ -28,6 +28,11 @@ on:
         default: ${{ github.sha }}
         type: string
 
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: read
+
 jobs:
   draft:
     runs-on: ["ubuntu-latest"]

--- a/.github/workflows/workflow-controller-draft-release.yml
+++ b/.github/workflows/workflow-controller-draft-release.yml
@@ -16,8 +16,6 @@ name: |-
         uses:  ./.github/workflows/workflow-controller-draft-release.yml
         with:
           ref: $\{\{ github.sha \}\}
-        secrets:
-          github-private-actions-pat: $\{\{ secrets.github-private-actions-pat \}\}
 
   ```
 
@@ -30,10 +28,6 @@ on:
         default: ${{ github.sha }}
         type: string
 
-    secrets:
-      github-private-actions-pat:
-        description: "Github PAT allow to create release"
-        required: true
 jobs:
   draft:
     runs-on: ["ubuntu-latest"]
@@ -47,4 +41,4 @@ jobs:
           config-name: configs/draft-release.yml
           commitish: ${{ inputs.ref }}
         env:
-          GITHUB_TOKEN: ${{ secrets.github-private-actions-pat }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow-controller-hotfix-reintegrate.yml
+++ b/.github/workflows/workflow-controller-hotfix-reintegrate.yml
@@ -37,6 +37,12 @@ on:
       github-private-actions-pat:
         description: "Github PAT allow to create a pull request"
         required: true
+
+permissions:
+  contents: write
+  id-token: write
+  pull-request: read
+
 jobs:
   changes:
     runs-on: ["ubuntu-latest"]

--- a/.github/workflows/workflow-controller-hotfix-release-branch.yml
+++ b/.github/workflows/workflow-controller-hotfix-release-branch.yml
@@ -26,6 +26,10 @@ on:
         required: true
         type: string
 
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   release-branch:
     runs-on: ["ubuntu-latest"]

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
## what
- Added all our typically GitHub checks and PR template
- Fixed token for release drafter
- Removed redundant `concurrency` and `permissions` settings

## why
- QoL improvements for Pull Requests
- We dont need a special token to draft a release. Plus if we do create a PAT, it should only have read access to the private config
- `concurrency` needs only to be set once and should be set at the top level. Where the workflow is started
- `permissions` needs only to be set once and should be set where the permissions are required. Any reusable workflow should define what permission that workflow needs

## references
- customer engagement