### PR TITLE
Add deprecation notice to repository README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@
 
 -->
 
+> [!WARNING]
+> **This repository is deprecated.** Please use [app-on-ecs-v2](https://github.com/cloudposse-examples/app-on-ecs-v2) instead.
+
 Example Dockerized application deployed on ECS.
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -41,6 +41,9 @@ related:
 
 # Short description of this project
 description: |-
+  > [!WARNING]
+  > **This repository is deprecated.** Please use [app-on-ecs-v2](https://github.com/cloudposse-examples/app-on-ecs-v2) instead.
+
   Example Dockerized application deployed on ECS.
 
 usage: |-


### PR DESCRIPTION
## what

- Added GitHub warning admonition to README.md and README.yaml
- Informs users that this repository is deprecated in favor of [app-on-ecs-v2](https://github.com/cloudposse-examples/app-on-ecs-v2)

## why

- This repository is deprecated and should not be used for new projects
- Users need to be clearly notified on the repository homepage to redirect them to the maintained version

## references

- Deprecated in favor of: https://github.com/cloudposse-examples/app-on-ecs-v2